### PR TITLE
Pinning zeek package manager version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,10 @@ COPY --from=builder /usr/local/zeek /usr/local/zeek
 ENV ZEEKPATH .:/usr/local/zeek/share/zeek:/usr/local/zeek/share/zeek/policy:/usr/local/zeek/share/zeek/site
 ENV PATH $PATH:/usr/local/zeek/bin
 
+ARG ZKG_VERSION=2.1.2
 ARG ZEEK_DEFAULT_PACKAGES="bro-interface-setup bro-doctor ja3"
 # install Zeek package manager
-RUN pip install zkg \
+RUN pip install zkg==$ZKG_VERSION \
   && zkg autoconfig \
   && zkg refresh \
   && zkg install --force $ZEEK_DEFAULT_PACKAGES


### PR DESCRIPTION
There is an issue with zkg version 2.2.0 where certain packages aren't installed correctly and cause Zeek to fail to start. Specifically, [ncsa/bro-interface-setup](https://packages.zeek.org/packages/view/12ae236d-f435-11e9-9321-0a645a3f3086) and [ncsa/bro-doctor](https://packages.zeek.org/packages/view/1251f948-f435-11e9-9321-0a645a3f3086) have this issue while the ja3 package does not. Reverting to zkg 2.1.2 fixes these issues.