### PR TITLE
Update TCP inactivity time out to 60 minutes

### DIFF
--- a/share/zeek/site/local.zeek
+++ b/share/zeek/site/local.zeek
@@ -102,3 +102,7 @@
 
 # Auto load installed packages from the Zeek package manager
 @load packages
+
+# This is important for accurate connection info. More info here: 
+# https://www.activecountermeasures.com/fixing-bro-zeeks-long-connection-detection-problem/
+redef tcp_inactivity_timeout = 60 min;


### PR DESCRIPTION
I've used this enough in the wild to consider making this the default.