### PR TITLE
Revamp automated build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: [ master, build ]
+    branches: [ master ]
     paths:
       # Paths that trigger a docker image build
       - '.github/workflows/docker-build.yml'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,10 +18,10 @@ jobs:
 
     strategy:
       matrix:
-        # allows using the same steps for multiple versions
+        # allows using the same build steps for multiple versions
         include:
           - version: "3.2.3"
-            tag: feature # extra info to associate with version
+            tag: latest # extra info to associate with version
           - version: "3.0.12"
             tag: lts # extra info to associate with version
 
@@ -52,12 +52,11 @@ jobs:
       id: prep
       run: |
         DOCKER_IMAGE=activecm/zeek
+        # e.g. lts or latest
+        TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}"
         if [ "${{ matrix.tag }}" == "lts" ]; then
-          TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}"
           # e.g. 3
           TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}"
-        else
-          TAGS="${DOCKER_IMAGE}:latest"
         fi
         # e.g. 3.0
         TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master, build ]
     paths:
       # Paths that trigger a docker image build
-      - '.github/workflows/*.yml'
+      - '.github/workflows/docker-build.yml'
       - 'etc/**'
       - 'share/**'
       - 'docker-entrypoint.sh'
@@ -21,9 +21,9 @@ jobs:
         # allows using the same steps for multiple versions
         include:
           - version: "3.2.3"
-            tag: "feature" # extra info to associate with version
+            tag: feature # extra info to associate with version
           - version: "3.0.12"
-            tag: "lts" # extra info to associate with version
+            tag: lts # extra info to associate with version
 
     steps:
     - 
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ matrix.version }}
         restore-keys: |
           ${{ runner.os }}-buildx-
     - 
@@ -84,16 +84,3 @@ jobs:
         push: true
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
-
-  description:
-    needs: build
-    name: Update Docker Zeek description
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Update repo description
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-          repository: activecm/zeek

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,8 +77,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
-        platforms: linux/amd64,linux/arm64
-        repository: activecm/zeek
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
         tags: ${{ steps.prep.outputs.tags }}
         build-args: ZEEK_VERSION=${{ matrix.version }}
         push: true

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -19,4 +19,4 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
           repository: activecm/zeek
-          readme-filepath: Readme.md
+          readme-filepath: ./Readme.md

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -1,0 +1,22 @@
+name: Update Docker Description
+
+on:
+  push:
+    branches: [ master, build ]
+    paths:
+      - '.github/workflows/docker-description.yml'
+      - 'Readme.md'
+
+jobs:
+  description:
+    name: Update Docker Zeek description
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: activecm/zeek
+          readme-filepath: Readme.md

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -12,6 +12,9 @@ jobs:
     name: Update Docker Zeek description
     runs-on: ubuntu-latest
     steps:
+      - 
+        name: Checkout code
+        uses: actions/checkout@v2
       -
         name: Update repo description
         uses: peter-evans/dockerhub-description@v2

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -2,7 +2,8 @@ name: Update Docker Description
 
 on:
   push:
-    branches: [ master, build ]
+    # https://github.com/peter-evans/dockerhub-description/issues/10
+    branches: [disabled] # purposely disabled as this doesn't work with Docker access tokens
     paths:
       - '.github/workflows/docker-description.yml'
       - 'Readme.md'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,11 +75,7 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64
         repository: activecm/zeek
-        tags: |
-          activecm/zeek:${{ matrix.tag }}
-          ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
-          activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
-          activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+        tags: ${{ steps.prep.outputs.tags }}
         build-args: ZEEK_VERSION=${{ matrix.version }}
     #     push: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
           echo ${{ matrix.version }}
           echo activecm/zeek:${{ matrix.tag }}
-          echo ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
+          echo ${{ if("${{ matrix.tag }}" == "lts", "activecm/zeek:${{ steps.semver_parser.outputs.major }}") }}
           echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
           echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
     # - 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,15 +48,16 @@ jobs:
       with:
         input_string: "${{ matrix.version }}"
     -
-      name: Prepare tags
+      name: Prepare docker tags
       id: prep
       run: |
         DOCKER_IMAGE=activecm/zeek
-        # e.g. lts, feature
-        TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}"
         if [ "${{ matrix.tag }}" == "lts" ]; then
+          TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}"
           # e.g. 3
-          TAGS="$TAGS,"${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}""
+          TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}"
+        else
+          TAGS="${DOCKER_IMAGE}:latest"
         fi
         # e.g. 3.0
         TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: [ master ]
+    branches: [ build ]
     paths:
       # Paths that trigger a docker image build
       - 'etc/**'
@@ -11,34 +11,73 @@ on:
       - 'Dockerfile'
 
 jobs:
-  feature:
-    name: Build Zeek feature release
+
+  build:
+    name: Build Zeek release
     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: docker/build-push-action@v1
-      with:
-        repository: activecm/zeek
-        tags: latest,3.2,3.2.3
-        build_args: ZEEK_VERSION=3.2.3
-        cache_froms: activecm/zeek:latest
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-
-  lts:
-    name: Build Zeek LTS release
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - version: "3.2.3"
+            tag: "feature"
+          - version: "3.0.12"
+            tag: "lts"
 
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: docker/build-push-action@v1
+    - 
+      name: Checkout code
+      uses: actions/checkout@v2
+    - 
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    -
+      name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    -
+      name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
-        repository: activecm/zeek
-        tags: lts,3,3.0,3.0.12
-        build_args: ZEEK_VERSION=3.0.12
-        cache_froms: activecm/zeek:lts
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
+    - 
+      name: Parse semver string
+      id: semver_parser 
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: "${{ matrix.version }}"
+    - 
+      name: Build and push
+      run: |
+          echo ${{ matrix.version }}
+          echo activecm/zeek:${{ matrix.tag }}
+          echo ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
+          echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
+          echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+    # - 
+    #   name: Build and push
+    #   uses: docker/build-push-action@v2
+    #   with:
+    #     platforms: linux/amd64,linux/arm64
+    #     repository: activecm/zeek
+    #     tags: |
+    #       activecm/zeek:${{ matrix.tag }}
+    #       ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
+    #       activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
+    #       activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+    #     build-args: ZEEK_VERSION=${{ matrix.version }}
+    #     push: true
+
+  # description:
+  #   needs: build
+  #   name: Update Docker Zeek description
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     -
+  #       name: Update repo description
+  #       uses: peter-evans/dockerhub-description@v2
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_TOKEN }}
+  #         repository: activecm/zeek

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     branches: [ build ]
     paths:
       # Paths that trigger a docker image build
+      - '.github/workflows/*.yml'
       - 'etc/**'
       - 'share/**'
       - 'docker-entrypoint.sh'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
         build-args: ZEEK_VERSION=${{ matrix.version }}
         push: true
         cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
 
   description:
     needs: build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: [ build ]
+    branches: [ master, build ]
     paths:
       # Paths that trigger a docker image build
       - '.github/workflows/*.yml'
@@ -12,25 +12,25 @@ on:
       - 'Dockerfile'
 
 jobs:
-
   build:
     name: Build Zeek release
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
+        # allows using the same steps for multiple versions
         include:
           - version: "3.2.3"
-            tag: "feature"
+            tag: "feature" # extra info to associate with version
           - version: "3.0.12"
-            tag: "lts"
+            tag: "lts" # extra info to associate with version
 
     steps:
     - 
       name: Checkout code
       uses: actions/checkout@v2
     - 
-      name: Set up QEMU
+      name: Set up QEMU # used for arm64 builds
       uses: docker/setup-qemu-action@v1
     -
       name: Setup Docker Buildx
@@ -42,13 +42,13 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
     - 
-      name: Parse semver string
+      name: Parse semver string # allows multiple docker tags like 3.0.0, 3.0, and 3
       id: semver_parser 
       uses: booxmedialtd/ws-action-parse-semver@v1
       with:
         input_string: "${{ matrix.version }}"
     -
-      name: Prepare docker tags
+      name: Prepare docker tags  # allows multiple docker tags like 3.0.0, 3.0, and 3
       id: prep
       run: |
         DOCKER_IMAGE=activecm/zeek
@@ -63,12 +63,16 @@ jobs:
         TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}"
         # e.g. 3.0.0
         TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}"
+        # make tags available to other actions steps as ${{ steps.prep.outputs.tags }}
         echo ::set-output name=tags::${TAGS}
-    # - 
-    #   name: Build and push
-    #   run: |
-    #       echo ${{ matrix.version }}
-    #       echo ${{ steps.prep.outputs.tags }}
+    -
+      name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
     - 
       name: Build and push
       uses: docker/build-push-action@v2
@@ -77,18 +81,19 @@ jobs:
         repository: activecm/zeek
         tags: ${{ steps.prep.outputs.tags }}
         build-args: ZEEK_VERSION=${{ matrix.version }}
-    #     push: true
+        push: true
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
-  # description:
-  #   needs: build
-  #   name: Update Docker Zeek description
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     -
-  #       name: Update repo description
-  #       uses: peter-evans/dockerhub-description@v2
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_TOKEN }}
-  #         repository: activecm/zeek
+  description:
+    needs: build
+    name: Update Docker Zeek description
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: activecm/zeek

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,23 +64,23 @@ jobs:
         # e.g. 3.0.0
         TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}"
         echo ::set-output name=tags::${TAGS}
-    - 
-      name: Build and push
-      run: |
-          echo ${{ matrix.version }}
-          echo ${{ steps.prep.outputs.tags }}
     # - 
     #   name: Build and push
-    #   uses: docker/build-push-action@v2
-    #   with:
-    #     platforms: linux/amd64,linux/arm64
-    #     repository: activecm/zeek
-    #     tags: |
-    #       activecm/zeek:${{ matrix.tag }}
-    #       ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
-    #       activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
-    #       activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
-    #     build-args: ZEEK_VERSION=${{ matrix.version }}
+    #   run: |
+    #       echo ${{ matrix.version }}
+    #       echo ${{ steps.prep.outputs.tags }}
+    - 
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64
+        repository: activecm/zeek
+        tags: |
+          activecm/zeek:${{ matrix.tag }}
+          ${{ if ("${{ matrix.tag }}" == "lts"), "activecm/zeek:${{ steps.semver_parser.outputs.major }}" }}
+          activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
+          activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+        build-args: ZEEK_VERSION=${{ matrix.version }}
     #     push: true
 
   # description:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,14 +47,27 @@ jobs:
       uses: booxmedialtd/ws-action-parse-semver@v1
       with:
         input_string: "${{ matrix.version }}"
+    -
+      name: Prepare tags
+      id: prep
+      run: |
+        DOCKER_IMAGE=activecm/zeek
+        # e.g. lts, feature
+        TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}"
+        if [ "${{ matrix.tag }}" == "lts" ]; then
+          # e.g. 3
+          TAGS="$TAGS,"${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}""
+        fi
+        # e.g. 3.0
+        TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}"
+        # e.g. 3.0.0
+        TAGS="$TAGS,${DOCKER_IMAGE}:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}"
+        echo ::set-output name=tags::${TAGS}
     - 
       name: Build and push
       run: |
           echo ${{ matrix.version }}
-          echo activecm/zeek:${{ matrix.tag }}
-          echo ${{ if("${{ matrix.tag }}" == "lts", "activecm/zeek:${{ steps.semver_parser.outputs.major }}") }}
-          echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}
-          echo activecm/zeek:${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}.${{ steps.semver_parser.outputs.patch }}
+          echo ${{ steps.prep.outputs.tags }}
     # - 
     #   name: Build and push
     #   uses: docker/build-push-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as builder
+FROM alpine:3.12 as builder
 
 ARG ZEEK_VERSION=3.2.3
 ARG BUILD_PROCS=2
@@ -10,7 +10,7 @@ RUN apk add --no-cache -t .build-deps \
   linux-headers \
   openssl-dev \
   libpcap-dev \
-  python-dev \
+  python3-dev \
   zlib-dev \
   binutils \
   fts-dev \
@@ -54,18 +54,18 @@ RUN echo "===> Size of the Zeek install..." \
   && du -sh /usr/local/zeek
 
 ####################################################################################################
-FROM alpine:3.11
+FROM alpine:3.12
 
-# python & bash are needed for zeekctl scripts
+# python3 & bash are needed for zeekctl scripts
 # ethtool is needed to manage interface features
 # util-linux provides taskset command needed to pin CPUs
-# py-pip and git are needed for zeek's package manager
+# py3-pip and git are needed for zeek's package manager
 RUN apk --no-cache add \
   ca-certificates zlib openssl libstdc++ libpcap libmaxminddb libgcc fts \
-  python bash \
+  python3 bash \
   ethtool \
   util-linux \
-  py-pip git
+  py3-pip git
 
 RUN ln -s $(which ethtool) /sbin/ethtool
 
@@ -74,7 +74,7 @@ COPY --from=builder /usr/local/zeek /usr/local/zeek
 ENV ZEEKPATH .:/usr/local/zeek/share/zeek:/usr/local/zeek/share/zeek/policy:/usr/local/zeek/share/zeek/site
 ENV PATH $PATH:/usr/local/zeek/bin
 
-ARG ZKG_VERSION=2.2.1
+ARG ZKG_VERSION=2.7.1
 ARG ZEEK_DEFAULT_PACKAGES="bro-interface-setup bro-doctor ja3"
 # install Zeek package manager
 RUN pip install zkg==$ZKG_VERSION \

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 
-This project is meant to run a single-system Zeek cluster inside of a docker container. It is based on, but differs from [blacktop/zeek:zeekctl](https://hub.docker.com/r/blacktop/zeek) in that it focuses on running multiple Zeek processes with `zeekctl`. To that end, there are several helpful features included:
+[activecm/zeek](https://hub.docker.com/r/activecm/zeek) is meant to run a single-system Zeek cluster inside of a docker container. It is based on, but differs from [blacktop/zeek:zeekctl](https://hub.docker.com/r/blacktop/zeek) in that it focuses on running multiple Zeek processes with `zeekctl`. To that end, there are several helpful features included:
 
 - A [configuration wizard](https://github.com/activecm/zeekcfg) for generating a `node.cfg` cluster configuration
 - Will automatically run `zeekctl` on start and print a diagnostic report if it fails


### PR DESCRIPTION
- The `docker/build-push-action` used was updated to v2. This meant restructuring the workflow anyway.
- `docker/build-push-action@v2` uses buildx which enabled us to do cross-architecture builds. We now build and push images for arm/v7 and arm64 to support Raspberry Pi 3 & 4. 
- Implemented docker build caching. Compiling Zeek for all these versions and architectures takes hours. When something besides the Zeek version changes this caching should drastically reduce the time it takes to build. This appears to be working in some cases but I'm not confident it's working correctly across both matrix builds.
- Switched to using a matrix strategy to avoid duplicating steps for each Zeek version.
  - This required some extra steps to parse the version number in order to create the tags for the docker images automatically.
 - Updated `zkg` to v2.7.1. This also meant updating Python to v3. Surprisingly this seemed to work seamlessly.