### PR TITLE
Fix current logs symlink to point to host's manager spool

### DIFF
--- a/zeek
+++ b/zeek
@@ -169,7 +169,7 @@ main() {
 		$SUDO "${docker_cmd[@]}"
 
 		# Fix current symlink for the host (sleep to give Zeek time to finish starting)
-		(sleep 30s; $SUDO docker exec "$container" ln -sfn "../spool/manager" /usr/local/zeek/logs/current) &
+		(sleep 30s; $SUDO docker exec "$container" ln -sfn "$HOST_ZEEK/spool/manager" /usr/local/zeek/logs/current) &
 
 		;;
 	stop)


### PR DESCRIPTION
Fixes #31 where PR #30 created a regression which broke the symlink for the current logs on the docker host.