### PR TITLE
Revert "Fix current logs symlink to point to host's manager spool"

### DIFF
--- a/zeek
+++ b/zeek
@@ -169,7 +169,7 @@ main() {
 		$SUDO "${docker_cmd[@]}"
 
 		# Fix current symlink for the host (sleep to give Zeek time to finish starting)
-		(sleep 30s; $SUDO docker exec "$container" ln -sfn "$HOST_ZEEK/spool/manager" /usr/local/zeek/logs/current) &
+		(sleep 30s; $SUDO docker exec "$container" ln -sfn "../spool/manager" /usr/local/zeek/logs/current) &
 
 		;;
 	stop)


### PR DESCRIPTION
Reverts activecm/docker-zeek#32

Turns out I just didn't wait long enough during my tests. The relative symlink *does* work on both the container and the host. Sorry for the mixup!