### PR TITLE
Remove maxmind support (never used)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG BUILD_PROCS=4
 RUN apk add --no-cache zlib openssl libstdc++ libpcap libgcc
 RUN apk add --no-cache -t .build-deps \
     bsd-compat-headers \
-    libmaxminddb-dev \
     linux-headers \
     openssl-dev \
     libpcap-dev \
@@ -69,7 +68,7 @@ FROM alpine AS final
 # util-linux provides taskset command needed to pin CPUs
 # py3-pip and git are needed for zeek's package manager
 RUN apk --no-cache add \
-    ca-certificates zlib openssl libstdc++ libpcap libmaxminddb libgcc fts krb5-libs \
+    ca-certificates zlib openssl libstdc++ libpcap libgcc fts krb5-libs \
     python3 bash \
     ethtool \
     util-linux \


### PR DESCRIPTION
Maxmind support gives a cosmetic error that the database can't be found.  We've never used geolocation inside Zeek.  Since getting this database requires setting up an account with maxmind and manually editing the docker image, we've decided to disable the support.  Confirmed that a docker image with this change no longer supports that module by running "zeek-config --have-geeoip" inside the container returns "no".