### PR TITLE
Update zeek - added command to remove docker volume zeek-zkg-script w…

### DIFF
--- a/zeek
+++ b/zeek
@@ -321,6 +321,7 @@ main() {
 		$SUDO docker pull "$IMAGE_NAME"
 
 		$0 stop
+		$SUDO docker volume rm zeek-zkg-script
 		$0 start
 		;;
 


### PR DESCRIPTION
…hen updating the container

Fixes the issue when upgrading the `docker-zeek` container where the container is running a zeek version less than 5.0 and upgrading to a zeek version 5.0 or greater. Specifically, the `ja3.zeek` script is not compatible when upgrading from < 5.0 to a version 5.0 >=.